### PR TITLE
Add generic polynomial

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ members = [
     "edwards25519",
     "ed25519",
     "pasta",
+    "polynomial",
 ]

--- a/polynomial/Cargo.toml
+++ b/polynomial/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "hacspec-polynomial"
+version = "0.1.0"
+authors = ["Lasse Bramer Schmidt <lassebramer@gmail.com>", "Rasmus Tomtava Bjerg <rs.bjerg@gmail.com>"]
+edition = "2018"
+
+[lib]
+path = "src/polynomial.rs"
+
+[dependencies]
+hacspec-lib = { git = "https://github.com/hacspec/hacspec.git" }
+
+[dev-dependencies]
+quickcheck = "1"
+quickcheck_macros = "1"

--- a/polynomial/src/polynomial.rs
+++ b/polynomial/src/polynomial.rs
@@ -112,7 +112,7 @@ impl<T: Numeric + NumericCopy + PartialEq> Add<T> for Polynomial<T> {
     fn add(self, other: T) -> Self {
         let mut c = self.coefficients;
         c[usize::zero()] = c[usize::zero()] + other;
-        Polynomial { coefficients: c }
+        (Polynomial { coefficients: c }).trim()
     }
 }
 
@@ -175,7 +175,7 @@ impl<T: Numeric + NumericCopy + PartialEq> Mul<T> for Polynomial<T> {
         for i in 0..c.len() {
             c[i] = c[i] * rhs;
         }
-        Polynomial { coefficients: c }
+        (Polynomial { coefficients: c }).trim()
     }
 }
 
@@ -222,7 +222,7 @@ impl<T: Numeric + NumericCopy + PartialEq + hacspec_lib::Div<Output = T>> Div<T>
         for i in 0..c.len() {
             c[i] = c[i] / rhs;
         }
-        Polynomial { coefficients: c }
+        (Polynomial { coefficients: c }).trim()
     }
 }
 
@@ -517,4 +517,3 @@ fn test_scalar_div(p: Polynomial<FpPallas>, x: u128, scalar: u128) {
     let p_modified_eval = p_modified.evaluate(x);
     assert_eq!(p_eval / scalar, p_modified_eval);
 }
-

--- a/polynomial/src/polynomial.rs
+++ b/polynomial/src/polynomial.rs
@@ -1,0 +1,520 @@
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+#![allow(warnings, unused)]
+
+use hacspec_lib::*;
+
+pub struct Polynomial<T: Numeric + NumericCopy + Clone> {
+    coefficients: Seq<T>,
+}
+
+impl<T: Numeric + NumericCopy + PartialEq> Polynomial<T> {
+    /// Create a polynomial, defined from its coefficient form
+    ///
+    /// # Arguments
+    ///
+    /// * `coefficients` - the polynomial in coefficient form
+    pub fn new(coefficients: Seq<T>) -> Polynomial<T> {
+        (Polynomial { coefficients }).trim()
+    }
+
+    /// Get a clone of the coefficients (useful for printing)
+    pub fn coeffs(&self) -> Seq<T> {
+        self.coefficients.clone()
+    }
+
+    /// Evaluate a polynomial at point, return the evaluation
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - the point
+    pub fn evaluate(self, x: T) -> T {
+        let coefficients = self.coefficients;
+        let mut result = T::default();
+
+        for i in 0..coefficients.len() {
+            result = result + coefficients[i] * x.exp(i as u32);
+        }
+
+        result
+    }
+
+    /// Get the polynomial trimmed of trailing zeros
+    /// Mostly for internal use
+    fn trim(&self) -> Polynomial<T> {
+        let len = self.coefficients.len();
+        for i in (1..len).rev() {
+            if self.coefficients[i] != T::default() {
+                return Polynomial {
+                    coefficients: self.coefficients.slice(0, i + usize::one()),
+                };
+            }
+        }
+        Polynomial {
+            coefficients: self.coefficients.slice(0, usize::one()),
+        }
+    }
+
+    /// Get the degree of the polynomial
+    pub fn degree(&self) -> usize {
+        self.trim().coefficients.len()
+    }
+
+    /// Get the coefficient of the leading term
+    pub fn leading_term(&self) -> T {
+        let coeffs = self.trim().coefficients;
+        coeffs[coeffs.len() - usize::one()]
+    }
+
+    /// Get the coefficient of the term at some degree
+    ///
+    /// # Arguments
+    ///
+    /// * `degree` - the degree to get coefficient for
+    pub fn get_coefficient(&self, degree: usize) -> T {
+        if self.trim().coefficients.len() > degree {
+            self.coefficients[degree]
+        } else {
+            T::default()
+        }
+    }
+}
+
+impl<T: Numeric + NumericCopy + PartialEq> Add<Polynomial<T>> for Polynomial<T> {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        let lhs = self.coefficients;
+        let rhs = other.coefficients;
+        let (big, small) = {
+            if lhs.len() > rhs.len() {
+                (lhs, rhs)
+            } else {
+                (rhs, lhs)
+            }
+        };
+
+        let mut result = big.clone();
+        for i in 0..small.len() {
+            result[i] = result[i].add(small[i]);
+        }
+
+        return (Polynomial {
+            coefficients: result,
+        })
+        .trim();
+    }
+}
+
+impl<T: Numeric + NumericCopy + PartialEq> Add<T> for Polynomial<T> {
+    type Output = Self;
+
+    fn add(self, other: T) -> Self {
+        let mut c = self.coefficients;
+        c[usize::zero()] = c[usize::zero()] + other;
+        Polynomial { coefficients: c }
+    }
+}
+
+impl<T: Numeric + NumericCopy + PartialEq> Sub<Polynomial<T>> for Polynomial<T> {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        let rhs = other.coefficients;
+
+        let mut neg_rhs = Seq::<T>::create(rhs.len());
+        for i in 0..rhs.len() {
+            neg_rhs[i] = T::default().sub(rhs[i]);
+        }
+
+        return self.clone()
+            + (Polynomial {
+                coefficients: neg_rhs,
+            });
+    }
+}
+
+impl<T: Numeric + NumericCopy + PartialEq> Sub<T> for Polynomial<T> {
+    type Output = Self;
+
+    fn sub(self, other: T) -> Self {
+        let mut c = self.coefficients;
+        c[usize::zero()] = c[usize::zero()] - other;
+        Polynomial { coefficients: c }
+    }
+}
+
+impl<T: Numeric + NumericCopy + PartialEq> Mul<Polynomial<T>> for Polynomial<T> {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        let lhs = self.coefficients;
+        let rhs = rhs.coefficients;
+        let mut result = Seq::<T>::create(lhs.len() + rhs.len());
+        for i in 0..lhs.len() {
+            if !lhs[i].equal(T::default()) {
+                for j in 0..rhs.len() {
+                    if !rhs[j].equal(T::default()) {
+                        result[i + j] = (result[i + j].add(lhs[i] * rhs[j]));
+                    }
+                }
+            }
+        }
+        (Polynomial {
+            coefficients: result,
+        })
+        .trim()
+    }
+}
+
+impl<T: Numeric + NumericCopy + PartialEq> Mul<T> for Polynomial<T> {
+    type Output = Self;
+
+    fn mul(self, rhs: T) -> Self::Output {
+        let mut c = self.coefficients;
+        for i in 0..c.len() {
+            c[i] = c[i] * rhs;
+        }
+        Polynomial { coefficients: c }
+    }
+}
+
+impl<T: Numeric + NumericCopy + PartialEq + hacspec_lib::Div<Output = T>> Div<Polynomial<T>>
+    for Polynomial<T>
+{
+    type Output = (Self, Self);
+
+    fn div(self, rhs: Self) -> Self::Output {
+        let mut q = Polynomial::<T>::default();
+        let mut r = self.clone();
+
+        if rhs.degree() > self.degree() {
+            return (q.trim(), r.trim());
+        }
+
+        let mut loop_upper_bound = rhs.degree();
+        if self.degree() > rhs.degree() {
+            loop_upper_bound = self.degree();
+        }
+
+        for _ in 0..loop_upper_bound {
+            if r.trim() != Polynomial::<T>::default() && r.degree() >= rhs.degree() {
+                let degree_diff = r.degree() - rhs.degree();
+                let mut t = Seq::<T>::create(degree_diff + usize::one());
+                t[degree_diff] = r.leading_term() / rhs.leading_term();
+                let t = Polynomial { coefficients: t };
+
+                q = q + t.clone();
+                let aux_prod = rhs.clone() * t;
+                r = r - aux_prod;
+            }
+        }
+
+        (q.trim(), r.trim())
+    }
+}
+
+impl<T: Numeric + NumericCopy + PartialEq + hacspec_lib::Div<Output = T>> Div<T> for Polynomial<T> {
+    type Output = Self;
+
+    fn div(self, rhs: T) -> Self {
+        let mut c = self.coefficients;
+        for i in 0..c.len() {
+            c[i] = c[i] / rhs;
+        }
+        Polynomial { coefficients: c }
+    }
+}
+
+impl<T: Numeric + NumericCopy + PartialEq> PartialEq for Polynomial<T> {
+    fn eq(&self, other: &Self) -> bool {
+        let lhs = &self.trim().coefficients;
+        let rhs = &other.trim().coefficients;
+
+        if lhs.len() != rhs.len() {
+            return false;
+        } else {
+            for i in 0..lhs.len() {
+                if lhs[i] != rhs[i] {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+}
+
+impl<T: Numeric + NumericCopy + PartialEq> Default for Polynomial<T> {
+    /// Constant polynomial with value T::default
+    fn default() -> Self {
+        Polynomial {
+            coefficients: Seq::<T>::create(1),
+        }
+    }
+}
+
+// TESTS
+
+#[cfg(test)]
+extern crate quickcheck;
+#[cfg(test)]
+#[macro_use(quickcheck)]
+extern crate quickcheck_macros;
+#[cfg(test)]
+use quickcheck::*;
+
+#[cfg(test)] // as to not export it
+public_nat_mod!(
+    type_name: FpPallas,
+    type_of_canvas: PallasCanvas,
+    bit_size_of_field: 255,
+    modulo_value: "40000000000000000000000000000000224698FC094CF91B992D30ED00000001"
+);
+
+impl<T: Numeric + NumericCopy> Clone for Polynomial<T> {
+    fn clone(&self) -> Self {
+        Polynomial {
+            coefficients: self.coefficients.clone(),
+        }
+    }
+}
+
+// Only needed for test/Arbitrary (and mut refs are not supported)
+#[cfg(test)]
+impl<T: Numeric + NumericCopy> Debug for Polynomial<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.coefficients)
+    }
+}
+
+#[cfg(test)]
+impl<T: Numeric + NumericCopy> Display for Polynomial<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.coefficients)
+    }
+}
+
+#[cfg(test)]
+impl Arbitrary for Polynomial<FpPallas> {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Polynomial<FpPallas> {
+        let size = usize::arbitrary(g) % 20 + 1;
+        let mut v: Vec<FpPallas> = vec![];
+        for _ in 0..size {
+            let new_val = FpPallas::from_literal(u128::arbitrary(g));
+            v.push(new_val);
+        }
+        Polynomial {
+            coefficients: Seq::from_vec(v),
+        }
+    }
+}
+
+// For testing, a constant polynomial with value 1
+#[cfg(test)]
+fn constant_one_poly_pallas() -> Polynomial<FpPallas> {
+    let mut c = Seq::<FpPallas>::create(1);
+    c[usize::zero()] = FpPallas::ONE();
+    Polynomial { coefficients: c }
+}
+
+// Addition
+
+#[cfg(test)]
+#[quickcheck]
+fn test_poly_add_logic(p1: Polynomial<FpPallas>, p2: Polynomial<FpPallas>, x: usize) {
+    let x = FpPallas::from_literal(x as u128);
+    let sum_poly = p1.clone() + p2.clone();
+
+    let expected = p1.evaluate(x) + p2.evaluate(x);
+    let actual = sum_poly.evaluate(x);
+    assert_eq!(expected, actual);
+}
+
+#[cfg(test)]
+#[quickcheck]
+fn test_poly_add_closure(p1: Polynomial<FpPallas>, p2: Polynomial<FpPallas>) {
+    let p3 = p1 + p2;
+}
+
+#[cfg(test)]
+#[quickcheck]
+fn test_poly_add_associativity(
+    p1: Polynomial<FpPallas>,
+    p2: Polynomial<FpPallas>,
+    p3: Polynomial<FpPallas>,
+) {
+    let p4 = p1.clone() + p2.clone();
+    let p4 = p4.clone() + p3.clone();
+    let p5 = p2.clone() + p3.clone();
+    let p5 = p5.clone() + p1.clone();
+    assert_eq!(p4, p5);
+}
+
+#[cfg(test)]
+#[quickcheck]
+fn test_poly_add_identity(p1: Polynomial<FpPallas>) {
+    let p2 = p1.clone() + Polynomial::<FpPallas>::default();
+
+    let p3 = Polynomial::<FpPallas>::default() + p1.clone();
+    assert_eq!(p1, p2);
+    assert_eq!(p3, p2);
+}
+
+// Subtraction
+
+#[cfg(test)]
+#[quickcheck]
+fn test_poly_sub(p1: Polynomial<FpPallas>, p2: Polynomial<FpPallas>, x: u128) {
+    let x = FpPallas::from_literal(x);
+    let sum_poly = p1.clone() - p2.clone();
+
+    let expected = p1.evaluate(x) - p2.evaluate(x);
+    let actual = sum_poly.evaluate(x);
+    assert_eq!(expected, actual);
+}
+
+// Addition / Subtraction
+
+#[cfg(test)]
+#[quickcheck]
+fn test_poly_add_inverse(p1: Polynomial<FpPallas>) {
+    let p1_inv = Polynomial::<FpPallas>::default() - p1.clone();
+    let p3 = p1.clone() + p1_inv.clone();
+    let p4 = p1_inv + p1;
+    assert_eq!(p3, p4);
+    assert_eq!(p3, Polynomial::<FpPallas>::default());
+}
+
+// Multiplication
+
+#[cfg(test)]
+#[quickcheck]
+fn test_poly_mul_logic(p1: Polynomial<FpPallas>, p2: Polynomial<FpPallas>, x: u128) {
+    let x = FpPallas::from_literal(x);
+    let mul_poly = p1.clone() * p2.clone();
+
+    let expected = p1.evaluate(x) * p2.evaluate(x);
+    let actual = mul_poly.evaluate(x);
+    assert_eq!(expected, actual);
+}
+
+#[cfg(test)]
+#[quickcheck]
+fn test_poly_mul_closure(p1: Polynomial<FpPallas>, p2: Polynomial<FpPallas>) {
+    let p3 = p1 * p2;
+}
+
+#[cfg(test)]
+#[quickcheck]
+fn test_poly_mul_associativity(
+    p1: Polynomial<FpPallas>,
+    p2: Polynomial<FpPallas>,
+    p3: Polynomial<FpPallas>,
+) {
+    let p4 = p1.clone() * p2.clone();
+    let p4 = p4.clone() * p3.clone();
+    let p5 = p2.clone() * p3.clone();
+    let p5 = p5.clone() * p1.clone();
+    assert_eq!(p4, p5);
+}
+
+#[cfg(test)]
+#[quickcheck]
+fn test_poly_mul_identity(p1: Polynomial<FpPallas>) {
+    let mut const_one_poly = constant_one_poly_pallas();
+
+    let p2 = p1.clone() * const_one_poly.clone();
+    let p3 = const_one_poly.clone() * p1.clone();
+
+    assert_eq!(p1, p2);
+    assert_eq!(p2, p3);
+}
+
+#[cfg(test)]
+#[quickcheck]
+fn test_poly_mul_cummutativity(p1: Polynomial<FpPallas>, p2: Polynomial<FpPallas>) {
+    let p3 = p1.clone() * p2.clone();
+    let p4 = p2 * p1.clone();
+    assert_eq!(p3, p4);
+}
+
+#[cfg(test)]
+#[quickcheck]
+fn test_poly_mul_left_distributive(
+    p1: Polynomial<FpPallas>,
+    p2: Polynomial<FpPallas>,
+    p3: Polynomial<FpPallas>,
+) {
+    let p4 = p1.clone() * (p2.clone() + p3.clone());
+    let p5 = (p1.clone() * p2) + (p1 * p3);
+    assert_eq!(p4, p5);
+}
+
+// Division
+
+#[cfg(test)]
+#[quickcheck]
+fn test_poly_div(p1: Polynomial<FpPallas>, p2: Polynomial<FpPallas>, x: u128) {
+    if p2.degree() > 0 {
+        let x = FpPallas::from_literal(x);
+
+        let (q, r) = p1.clone() / p2.clone();
+        let eval_q = q.evaluate(x);
+        let eval_r = r.evaluate(x);
+        let eval_p1 = p1.evaluate(x);
+        let eval_p2 = p2.evaluate(x);
+        let eval_r_div = eval_r / eval_p2;
+
+        let expected = eval_p1 / eval_p2;
+        let actual = eval_q + eval_r_div;
+
+        assert_eq!(expected, actual);
+    }
+}
+
+// Scalar tests
+
+#[cfg(test)]
+#[quickcheck]
+fn test_scalar_add(p: Polynomial<FpPallas>, x: u128, scalar: u128) {
+    let x = FpPallas::from_literal(x);
+    let scalar = FpPallas::from_literal(scalar);
+    let p_modified = p.clone() + scalar;
+    let p_eval = p.evaluate(x);
+    let p_modified_eval = p_modified.evaluate(x);
+    assert_eq!(p_eval + scalar, p_modified_eval);
+}
+
+#[cfg(test)]
+#[quickcheck]
+fn test_scalar_sub(p: Polynomial<FpPallas>, x: u128, scalar: u128) {
+    let x = FpPallas::from_literal(x);
+    let scalar = FpPallas::from_literal(scalar);
+    let p_modified = p.clone() - scalar;
+    let p_eval = p.evaluate(x);
+    let p_modified_eval = p_modified.evaluate(x);
+    assert_eq!(p_eval - scalar, p_modified_eval);
+}
+
+#[cfg(test)]
+#[quickcheck]
+fn test_scalar_mul(p: Polynomial<FpPallas>, x: u128, scalar: u128) {
+    let x = FpPallas::from_literal(x);
+    let scalar = FpPallas::from_literal(scalar);
+    let p_modified = p.clone() * scalar;
+    let p_eval = p.evaluate(x);
+    let p_modified_eval = p_modified.evaluate(x);
+    assert_eq!(p_eval * scalar, p_modified_eval);
+}
+
+#[cfg(test)]
+#[quickcheck]
+fn test_scalar_div(p: Polynomial<FpPallas>, x: u128, scalar: u128) {
+    let x = FpPallas::from_literal(x);
+    let scalar = FpPallas::from_literal(scalar);
+    let p_modified = p.clone() / scalar;
+    let p_eval = p.evaluate(x);
+    let p_modified_eval = p_modified.evaluate(x);
+    assert_eq!(p_eval / scalar, p_modified_eval);
+}
+

--- a/polynomial/src/polynomial.rs
+++ b/polynomial/src/polynomial.rs
@@ -4,7 +4,8 @@
 
 use hacspec_lib::*;
 
-pub struct Polynomial<T: Numeric + NumericCopy> {
+/// A generic representation of polynomial
+pub struct Polynomial<T: Numeric + NumericCopy + Clone> {
     coefficients: Seq<T>,
 }
 
@@ -79,6 +80,9 @@ impl<T: Numeric + NumericCopy + PartialEq> Polynomial<T> {
         }
     }
 }
+
+
+/// We wil now define the ring operations on polynomials.
 
 impl<T: Numeric + NumericCopy + PartialEq> Add<Polynomial<T>> for Polynomial<T> {
     type Output = Self;

--- a/polynomial/src/polynomial.rs
+++ b/polynomial/src/polynomial.rs
@@ -4,7 +4,7 @@
 
 use hacspec_lib::*;
 
-pub struct Polynomial<T: Numeric + NumericCopy + Clone> {
+pub struct Polynomial<T: Numeric + NumericCopy> {
     coefficients: Seq<T>,
 }
 


### PR DESCRIPTION
This is an attempt at a hacspec v2 compliant generic (uni-variate) polynomial spec.

It supports
* polynomial-polynomial addition/subtraction/multiplication/division
* polynomial-scalar addition/subtraction/multiplication/division
* evaluation
* Some convenience functions for getting degree, coefficient form, ...

As of 17-06-2023 (via docker image):
*  `cargo-hax lint hacspec` returns no errors or warnings
* `cargo-hax into coq` gives
```
bash-5.2# cargo-hax into coq
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
   Compiling hacspec-pasta v1.0.0 (/work/examples/pasta)
note: Writing file "/work/examples/polynomial/out/Hacspec_pasta.v"

   Compiling hacspec-polynomial v0.1.0 (/work/examples/polynomial)
error[CE0001]: (Diagnostics.Context.Phase FunctionalizeLoops): something is not implemented yet.
               Loop without mutation?
  --> polynomial/src/polynomial.rs:46:9
   |
46 | /         for i in (1..len).rev() {
47 | |             if self.coefficients[i] != T::default() {
48 | |                 return Polynomial {
49 | |                     coefficients: self.coefficients.slice(0, i + usize::one()),
50 | |                 };
51 | |             }
52 | |         }
   | |_________^

error[CE0001]: (Diagnostics.Context.Phase CfIntoMonads): something is not implemented yet.This is discussed in issue https://github.com/hacspec/hacspec-v2/issues/96.
               Please upvote or comment this issue if you see this error message.
               TODO: Monad for loop-related control flow
   --> polynomial/src/polynomial.rs:200:9
    |
200 | /         for _ in 0..loop_upper_bound {
201 | |             if r.trim() != Polynomial::<T>::default() && r.degree() >= rhs.degree() {
202 | |                 let degree_diff = r.degree() - rhs.degree();
203 | |                 let mut t = Seq::<T>::create(degree_diff + usize::one());
...   |
210 | |             }
211 | |         }
    | |_________^

error[CE0001]: (Diagnostics.Context.Phase FunctionalizeLoops): something is not implemented yet.
               Only for loop are being functionalized for now
   --> polynomial/src/polynomial.rs:200:9
    |
200 | /         for _ in 0..loop_upper_bound {
201 | |             if r.trim() != Polynomial::<T>::default() && r.degree() >= rhs.degree() {
202 | |                 let degree_diff = r.degree() - rhs.degree();
203 | |                 let mut t = Seq::<T>::create(degree_diff + usize::one());
...   |
210 | |             }
211 | |         }
    | |_________^

error[CE0001]: (Diagnostics.Context.Phase FunctionalizeLoops): something is not implemented yet.
               Loop without mutation?
   --> polynomial/src/polynomial.rs:236:16
    |
236 |           } else {
    |  ________________^
237 | |             for i in 0..lhs.len() {
238 | |                 if lhs[i] != rhs[i] {
239 | |                     return false;
240 | |                 }
241 | |             }
242 | |         }
    | |_________^

error[CE0001]: (Diagnostics.Context.Backend Coq): something is not implemented yet.
               [ty] node typ
   --> polynomial/src/polynomial.rs:83:1
    |
83  | / impl<T: Numeric + NumericCopy + PartialEq> Add<Polynomial<T>> for Polynomial<T> {
84  | |     type Output = Self;
85  | |
86  | |     fn add(self, other: Self) -> Self {
...   |
106 | |     }
107 | | }
    | |_^

error[CE0001]: (Diagnostics.Context.Backend Coq): something is not implemented yet.
               [ty] node typ
   --> polynomial/src/polynomial.rs:109:1
    |
109 | / impl<T: Numeric + NumericCopy + PartialEq> Add<T> for Polynomial<T> {
110 | |     type Output = Self;
111 | |
112 | |     fn add(self, other: T) -> Self {
...   |
116 | |     }
117 | | }
    | |_^

error[CE0001]: (Diagnostics.Context.Backend Coq): something is not implemented yet.
               [ty] node typ
   --> polynomial/src/polynomial.rs:119:1
    |
119 | / impl<T: Numeric + NumericCopy + PartialEq> Sub<Polynomial<T>> for Polynomial<T> {
120 | |     type Output = Self;
121 | |
122 | |     fn sub(self, other: Self) -> Self {
...   |
134 | |     }
135 | | }
    | |_^

error[CE0001]: (Diagnostics.Context.Backend Coq): something is not implemented yet.
               [ty] node typ
   --> polynomial/src/polynomial.rs:137:1
    |
137 | / impl<T: Numeric + NumericCopy + PartialEq> Sub<T> for Polynomial<T> {
138 | |     type Output = Self;
139 | |
140 | |     fn sub(self, other: T) -> Self {
...   |
144 | |     }
145 | | }
    | |_^

error[CE0001]: (Diagnostics.Context.Backend Coq): something is not implemented yet.
               [ty] node typ
   --> polynomial/src/polynomial.rs:147:1
    |
147 | / impl<T: Numeric + NumericCopy + PartialEq> Mul<Polynomial<T>> for Polynomial<T> {
148 | |     type Output = Self;
149 | |
150 | |     fn mul(self, rhs: Self) -> Self::Output {
...   |
167 | |     }
168 | | }
    | |_^

error[CE0001]: (Diagnostics.Context.Backend Coq): something is not implemented yet.
               [ty] node typ
   --> polynomial/src/polynomial.rs:170:1
    |
170 | / impl<T: Numeric + NumericCopy + PartialEq> Mul<T> for Polynomial<T> {
171 | |     type Output = Self;
172 | |
173 | |     fn mul(self, rhs: T) -> Self::Output {
...   |
179 | |     }
180 | | }
    | |_^

error[CE0001]: (Diagnostics.Context.Backend Coq): something is not implemented yet.
               [ty] node typ
   --> polynomial/src/polynomial.rs:182:1
    |
182 | / impl<T: Numeric + NumericCopy + PartialEq + hacspec_lib::Div<Output = T>> Div<Polynomial<T>>
183 | |     for Polynomial<T>
184 | | {
185 | |     type Output = (Self, Self);
...   |
214 | |     }
215 | | }
    | |_^

error[CE0001]: (Diagnostics.Context.Backend Coq): something is not implemented yet.
               [ty] node typ
   --> polynomial/src/polynomial.rs:217:1
    |
217 | / impl<T: Numeric + NumericCopy + PartialEq + hacspec_lib::Div<Output = T>> Div<T> for Polynomial<T> {
218 | |     type Output = Self;
219 | |
220 | |     fn div(self, rhs: T) -> Self {
...   |
226 | |     }
227 | | }
    | |_^

note: Writing file "/work/examples/polynomial/out/Hacspec_polynomial.v"

error: could not compile `hacspec-polynomial` (lib) due to 12 previous errors
```
* `cargo-hax into fstar` gives
```
bash-5.2# cargo-hax into fstar
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
   Compiling hacspec-pasta v1.0.0 (/work/examples/pasta)
note: Writing file "/work/examples/polynomial/out/Hacspec_pasta.fst"

   Compiling hacspec-polynomial v0.1.0 (/work/examples/polynomial)
error[CE0001]: (Diagnostics.Context.Phase FunctionalizeLoops): something is not implemented yet.
               Loop without mutation?
  --> polynomial/src/polynomial.rs:46:9
   |
46 | /         for i in (1..len).rev() {
47 | |             if self.coefficients[i] != T::default() {
48 | |                 return Polynomial {
49 | |                     coefficients: self.coefficients.slice(0, i + usize::one()),
50 | |                 };
51 | |             }
52 | |         }
   | |_________^

error[CE0001]: (Diagnostics.Context.Phase CfIntoMonads): something is not implemented yet.This is discussed in issue https://github.com/hacspec/hacspec-v2/issues/96.
               Please upvote or comment this issue if you see this error message.
               TODO: Monad for loop-related control flow
   --> polynomial/src/polynomial.rs:200:9
    |
200 | /         for _ in 0..loop_upper_bound {
201 | |             if r.trim() != Polynomial::<T>::default() && r.degree() >= rhs.degree() {
202 | |                 let degree_diff = r.degree() - rhs.degree();
203 | |                 let mut t = Seq::<T>::create(degree_diff + usize::one());
...   |
210 | |             }
211 | |         }
    | |_________^

error[CE0001]: (Diagnostics.Context.Phase FunctionalizeLoops): something is not implemented yet.
               Only for loop are being functionalized for now
   --> polynomial/src/polynomial.rs:200:9
    |
200 | /         for _ in 0..loop_upper_bound {
201 | |             if r.trim() != Polynomial::<T>::default() && r.degree() >= rhs.degree() {
202 | |                 let degree_diff = r.degree() - rhs.degree();
203 | |                 let mut t = Seq::<T>::create(degree_diff + usize::one());
...   |
210 | |             }
211 | |         }
    | |_________^

error[CE0001]: (Diagnostics.Context.Phase FunctionalizeLoops): something is not implemented yet.
               Loop without mutation?
   --> polynomial/src/polynomial.rs:236:16
    |
236 |           } else {
    |  ________________^
237 | |             for i in 0..lhs.len() {
238 | |                 if lhs[i] != rhs[i] {
239 | |                     return false;
240 | |                 }
241 | |             }
242 | |         }
    | |_________^

error[CE0001]: (Diagnostics.Context.Backend FStar): something is not implemented yet.
               anonymous impl
  --> polynomial/src/polynomial.rs:11:1
   |
11 | / impl<T: Numeric + NumericCopy + PartialEq> Polynomial<T> {
12 | |     /// Create a polynomial, defined from its coefficient form
13 | |     ///
14 | |     /// # Arguments
...  |
80 | |     }
81 | | }
   | |_^

note: Writing file "/work/examples/polynomial/out/Hacspec_polynomial.fst"

error: could not compile `hacspec-polynomial` (lib) due to 5 previous errors
```