### PR TITLE
Sign flip in fsub

### DIFF
--- a/curve25519-rust/src/hacspec_helper.rs
+++ b/curve25519-rust/src/hacspec_helper.rs
@@ -18,7 +18,7 @@ pub trait NatMod<const LEN: usize> {
         let rhs = num_bigint::BigUint::from_bytes_be(rhs.value());
         let modulus = num_bigint::BigUint::from_bytes_be(&Self::MODULUS);
         let res = if lhs < rhs {
-            modulus.clone() - lhs + rhs
+            modulus.clone() + lhs - rhs
         } else {
             lhs - rhs
         };


### PR DESCRIPTION
To illustrate, lets say `lhs = 0`, then the correct result of `lhs - rhs % p` should be `p - rhs`, not `p - lhs + rhs` = `p + rhs` = `rhs % p`.